### PR TITLE
Add dual-input preprocessing

### DIFF
--- a/dataset/data_loader/BP4DPlusLoader.py
+++ b/dataset/data_loader/BP4DPlusLoader.py
@@ -181,8 +181,8 @@ class BP4DPlusLoader(BaseLoader):
 
         target_length = frames.shape[0]
         bvps = BaseLoader.resample_ppg(bvps, target_length)
-        frames_clips, bvps_clips = self.preprocess(frames, bvps, config_preprocess)
-        input_name_list, label_name_list = self.save_multi_process(frames_clips, bvps_clips, saved_filename)
+        face_clips, bg_clips, bvps_clips = self.preprocess(frames, bvps, config_preprocess)
+        input_name_list, label_name_list = self.save_multi_process(face_clips, bg_clips, bvps_clips, saved_filename)
         file_list_dict[i] = input_name_list
 
     def read_video(self, data_dir, config_preprocess):

--- a/dataset/data_loader/MMPDLoader.py
+++ b/dataset/data_loader/MMPDLoader.py
@@ -116,9 +116,9 @@ class MMPDLoader(BaseLoader):
         frames = (np.round(frames * 255)).astype(np.uint8)
         target_length = frames.shape[0]
         bvps = BaseLoader.resample_ppg(bvps, target_length)
-        frames_clips, bvps_clips = self.preprocess(frames, bvps, config_preprocess)
+        face_clips, bg_clips, bvps_clips = self.preprocess(frames, bvps, config_preprocess)
 
-        input_name_list, label_name_list = self.save_multi_process(frames_clips, bvps_clips, saved_filename)
+        input_name_list, label_name_list = self.save_multi_process(face_clips, bg_clips, bvps_clips, saved_filename)
         file_list_dict[i] = input_name_list
 
     def read_mat(self, mat_file):

--- a/dataset/data_loader/PURELoader.py
+++ b/dataset/data_loader/PURELoader.py
@@ -123,8 +123,8 @@ class PURELoader(BaseLoader):
 
         target_length = frames.shape[0]
         bvps = BaseLoader.resample_ppg(bvps, target_length)
-        frames_clips, bvps_clips = self.preprocess(frames, bvps, config_preprocess)
-        input_name_list, label_name_list = self.save_multi_process(frames_clips, bvps_clips, saved_filename)
+        face_clips, bg_clips, bvps_clips = self.preprocess(frames, bvps, config_preprocess)
+        input_name_list, label_name_list = self.save_multi_process(face_clips, bg_clips, bvps_clips, saved_filename)
         file_list_dict[i] = input_name_list
 
     @staticmethod

--- a/dataset/data_loader/SCAMPSLoader.py
+++ b/dataset/data_loader/SCAMPSLoader.py
@@ -82,9 +82,9 @@ class SCAMPSLoader(BaseLoader):
         else:
             bvps = self.read_wave(matfile_path)
 
-        frames_clips, bvps_clips = self.preprocess(
+        face_clips, bg_clips, bvps_clips = self.preprocess(
             frames, bvps, config_preprocess)
-        input_name_list, label_name_list = self.save_multi_process(frames_clips, bvps_clips, saved_filename)
+        input_name_list, label_name_list = self.save_multi_process(face_clips, bg_clips, bvps_clips, saved_filename)
         file_list_dict[i] = input_name_list
 
     def preprocess_dataset_backup(self, data_dirs, config_preprocess):

--- a/dataset/data_loader/UBFCPHYSLoader.py
+++ b/dataset/data_loader/UBFCPHYSLoader.py
@@ -101,8 +101,8 @@ class UBFCPHYSLoader(BaseLoader):
 
         bvps = BaseLoader.resample_ppg(bvps, frames.shape[0])
             
-        frames_clips, bvps_clips = self.preprocess(frames, bvps, config_preprocess)
-        input_name_list, label_name_list = self.save_multi_process(frames_clips, bvps_clips, saved_filename)
+        face_clips, bg_clips, bvps_clips = self.preprocess(frames, bvps, config_preprocess)
+        input_name_list, label_name_list = self.save_multi_process(face_clips, bg_clips, bvps_clips, saved_filename)
         file_list_dict[i] = input_name_list
 
     def load_preprocessed_data(self):

--- a/dataset/data_loader/UBFCrPPGLoader.py
+++ b/dataset/data_loader/UBFCrPPGLoader.py
@@ -88,8 +88,8 @@ class UBFCrPPGLoader(BaseLoader):
             bvps = self.read_wave(
                 os.path.join(data_dirs[i]['path'],"ground_truth.txt"))
             
-        frames_clips, bvps_clips = self.preprocess(frames, bvps, config_preprocess)
-        input_name_list, label_name_list = self.save_multi_process(frames_clips, bvps_clips, saved_filename)
+        face_clips, bg_clips, bvps_clips = self.preprocess(frames, bvps, config_preprocess)
+        input_name_list, label_name_list = self.save_multi_process(face_clips, bg_clips, bvps_clips, saved_filename)
         file_list_dict[i] = input_name_list
 
     @staticmethod

--- a/dataset/data_loader/iBVPLoader.py
+++ b/dataset/data_loader/iBVPLoader.py
@@ -161,8 +161,8 @@ class iBVPLoader(BaseLoader):
         bvps = np.delete(bvps, del_idx, axis=0)
         sq_vec = np.delete(sq_vec, del_idx, axis=0)
 
-        frames_clips, bvps_clips = self.preprocess(frames, bvps, config_preprocess)
-        input_name_list, label_name_list = self.save_multi_process(frames_clips, bvps_clips, saved_filename)
+        face_clips, bg_clips, bvps_clips = self.preprocess(frames, bvps, config_preprocess)
+        input_name_list, label_name_list = self.save_multi_process(face_clips, bg_clips, bvps_clips, saved_filename)
         file_list_dict[i] = input_name_list
 
     @staticmethod

--- a/neural_methods/model/DualInputWrapper.py
+++ b/neural_methods/model/DualInputWrapper.py
@@ -1,0 +1,13 @@
+import torch.nn as nn
+
+class DualInputWrapper(nn.Module):
+    """Wrapper to allow models to accept two inputs.
+
+    The background input is currently ignored and only kept for API compatibility.
+    """
+    def __init__(self, base_model):
+        super().__init__()
+        self.base_model = base_model
+
+    def forward(self, face, background=None):
+        return self.base_model(face)


### PR DESCRIPTION
## Summary
- extend preprocessing to crop background ROI
- save face/background clips to NPZ
- adapt loaders for new outputs
- add dual-input wrapper and modify TSCAN trainer

## Testing
- `python -m py_compile neural_methods/trainer/TscanTrainer.py neural_methods/model/DualInputWrapper.py dataset/data_loader/BaseLoader.py dataset/data_loader/UBFCrPPGLoader.py dataset/data_loader/PURELoader.py dataset/data_loader/UBFCPHYSLoader.py dataset/data_loader/SCAMPSLoader.py dataset/data_loader/MMPDLoader.py dataset/data_loader/iBVPLoader.py dataset/data_loader/BP4DPlusLoader.py dataset/data_loader/PhysDriveLoader.py`

------
https://chatgpt.com/codex/tasks/task_e_685fcc0911888330a27da9fbfd3df08e